### PR TITLE
NTU-694 Prometheus-endpoints Certproxy

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: cert-proxy
         app.kubernetes.io/name: {{ .Values.deployment.name }}
+        monitoring: prometheus
     spec:
       imagePullSecrets:
         - name: regcred
@@ -27,6 +28,8 @@ spec:
         - name: trust-volume
           secret:
             secretName: {{ .Values.trust.secretName }}
+        - name: nginx-prometheus-exporter-tmp
+          emptyDir: {}
 
       containers:
         - name: cert-proxy-nginx
@@ -81,4 +84,30 @@ spec:
             - secretRef:
                 name: {{ . }}
             {{- end }}
+
+        # Sidecar container that exports NGINX metrics for Prometheus monitoring
+        - name: nginx-prometheus-exporter
+          image: "{{ .Values.nginxPrometheusExporter.image.repository }}:{{ .Values.nginxPrometheusExporter.image.tag }}"
+          args:
+            - --nginx.scrape-uri=http://127.0.0.1:9113/stub_status
+            - --web.listen-address=:8089
+            - --web.telemetry-path=/actuator/prometheus
+          ports:
+            - containerPort: 8089
+              name: metrics
+              protocol: TCP
+          volumeMounts:
+            - name: nginx-prometheus-exporter-tmp
+              mountPath: /tmp
+          resources:
+            {{- toYaml .Values.nginxPrometheusExporter.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            runAsUser: 65534 # nobody user
+            seccompProfile:
+              type: RuntimeDefault
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -68,3 +68,17 @@ probes:
     periodSeconds: 2  # 10s + 20 * 2s = 50 seconds max startup time
     successThreshold: 1
     timeoutSeconds: 1
+
+nginxPrometheusExporter:
+  image:
+    repository: nginx/nginx-prometheus-exporter
+    tag: 1.5.1
+  resources:
+    requests:
+      cpu: 10m
+      memory: 16Mi
+      ephemeral-storage: "1Mi"
+    limits:
+      cpu: 50m
+      memory: 32Mi
+      ephemeral-storage: "10Mi"

--- a/nginx-image/metrics.conf.template
+++ b/nginx-image/metrics.conf.template
@@ -1,0 +1,13 @@
+server {
+    listen       127.0.0.1:9113;
+    server_name  localhost;
+
+    # Disable logging for internal metrics endpoint
+    access_log  off;
+
+    # Internal stub_status for prometheus exporter sidecar
+    location /stub_status {
+        stub_status;
+    }
+}
+

--- a/nginx-image/nginx.conf
+++ b/nginx-image/nginx.conf
@@ -38,4 +38,5 @@ http {
 
     include /etc/nginx/conf.d/proxy.conf;
     include /etc/nginx/conf.d/health.conf;
+    include /etc/nginx/conf.d/metrics.conf;
 }


### PR DESCRIPTION
Ny intern end-point för att plocka ut mätvärden för nginx.
Ny container som konverterar värdena till Prometheus-format och som exponeras på "monitor-porten".